### PR TITLE
feat: change timeline to display only posts from friends

### DIFF
--- a/src/pages/TimelinePage.js
+++ b/src/pages/TimelinePage.js
@@ -60,9 +60,6 @@ export default function TimelinePage() {
         config,
       )
       .then((response) => {
-        if (response.status === 204) {
-          setFollowCount(0)
-        }
         setPosts([...response.data])
         setLoadedPosts(true)
       })

--- a/src/pages/TimelinePage.js
+++ b/src/pages/TimelinePage.js
@@ -12,26 +12,57 @@ import SearchBarMobile from "../components/SearchBar/SearchBarMobile.js"
 import profilePic from "../assets/profile-placeholder.jpg"
 
 import * as S from "../styles/style.js"
+import { useAuth } from "../hooks/useAuth.js"
 
 export default function TimelinePage() {
+  const { user } = useAuth()
   const [posts, setPosts] = useState(() => {
     getPosts()
   })
   const [loadedPosts, setLoadedPosts] = useState(false)
   const [loadPostsFail, setLoadPostsFail] = useState(false)
+  const [followCount, setFollowCount] = useState(() => {
+    getFollowCount()
+  })
 
   const theme = useTheme()
+
+  function getFollowCount() {
+    const config = {
+      headers: {
+        Authorization: `Bearer ${user?.token}`,
+      },
+    }
+
+    axios
+      .get(`${process.env.REACT_APP_API_URL}/follows`, config)
+      .then((response) => {
+        if (response.status === 204) setFollowCount(0)
+        else setFollowCount(response.data)
+      })
+      .catch((error) => {})
+  }
 
   function getPosts() {
     const LIMIT = 20
     const ORDERBY = "created_at"
     const ORDER_DIR = "desc"
 
+    const config = {
+      headers: {
+        Authorization: `Bearer ${user?.token}`,
+      },
+    }
+
     axios
       .get(
         `${process.env.REACT_APP_API_URL}/posts?limit=${LIMIT}&order=${ORDERBY}&direction=${ORDER_DIR}`,
+        config,
       )
       .then((response) => {
+        if (response.status === 204) {
+          setFollowCount(0)
+        }
         setPosts([...response.data])
         setLoadedPosts(true)
       })
@@ -42,8 +73,6 @@ export default function TimelinePage() {
   }
 
   function handleTryLoadAgain() {
-    console.log("rodei")
-
     setLoadedPosts(false)
     setLoadPostsFail(false)
     getPosts()
@@ -92,7 +121,11 @@ export default function TimelinePage() {
             )}
             {posts && posts.length === 0 && (
               <S.NoPostsContainer>
-                <p>There are no posts yet.</p>
+                {followCount === 0 ? (
+                  <p>You don't follow anyone yet. Search for new friends!</p>
+                ) : (
+                  <p>No posts found from your friends.</p>
+                )}
               </S.NoPostsContainer>
             )}
           </Posts>

--- a/src/pages/UserPostsPage.js
+++ b/src/pages/UserPostsPage.js
@@ -10,8 +10,10 @@ import UpdatePost from "../components/shared/Posts/updatePost.js"
 import Trending from "../components/shared/Trending/Trending.js"
 
 import * as S from "../styles/style.js"
+import { useAuth } from "../hooks/useAuth.js"
 
 export default function UserPostsPage() {
+  const { user } = useAuth()
   const { userId } = useParams()
 
   const [userInfo, setUserInfo] = useState(() => {
@@ -39,8 +41,14 @@ export default function UserPostsPage() {
   }
 
   function getUserPosts() {
+    const config = {
+      headers: {
+        Authorization: `Bearer ${user?.token}`,
+      },
+    }
+
     axios
-      .get(`${process.env.REACT_APP_API_URL}/posts/${userId}`)
+      .get(`${process.env.REACT_APP_API_URL}/posts/${userId}`, config)
       .then((response) => {
         setPosts(response.data)
         setLoadedPosts(true)
@@ -76,7 +84,7 @@ export default function UserPostsPage() {
           <Posts>
             {posts &&
               posts.map((post) => {
-                return <UpdatePost key={post.id} post={post}  />
+                return <UpdatePost key={post.id} post={post} />
               })}
             {!loadedPosts && (
               <S.LoadingPosts>


### PR DESCRIPTION
Now the user can only seen posts from it's friends. 

Since it need to know who the user is (and validate that is really that user, now the endpoint is authenticated in the back-end and therefore, a header is sent in the front-end request). Also changed the header sent on the user posts page. 